### PR TITLE
Add extra args config option

### DIFF
--- a/lib/composer.coffee
+++ b/lib/composer.coffee
@@ -18,13 +18,18 @@ class Composer
   _run: (command) ->
     closeOnComplete = atom.config.get 'composer.closeOnComplete'
     composerPath = atom.config.get 'composer.composerPath'
+    composerArgs = atom.config.get 'composer.composerArgs'
     firstRun = true
     [projectPath, ...] = atom.project.getPaths()
 
     projectPath ?= atom.config.get 'core.projectHome' or
       fs.getHomeDirectory()
 
-    args = [command, '-d', projectPath]
+    if command == 'install' || command == 'update'
+      args = [command, '-d', projectPath, composerArgs]
+    else
+      args = [command, '-d', projectPath]
+
     childProcess = spawn composerPath, args
     stdout = childProcess.stdout
     stderr = childProcess.stderr

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,6 +7,11 @@ module.exports =
       default: 'composer'
       title: 'Path to composer executable'
       type: 'string'
+    composerArgs:
+      default: ''
+      title: 'Extra arguments to apply to composer update/install commands, e.g. --prefer-dist'
+      type: 'string'
+
 
   activate: (state) ->
     @composer ?= new Composer


### PR DESCRIPTION
Adds a config option to allow users to specify extra arguments that are added to the install and update commands, e.g. --prefer-dist
